### PR TITLE
Direct package.json to an actual javascript file

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       "url": "http://opensource.org/licenses/MIT"
     }
   ],
-  "main": "./app",
+  "main": "./app/app.js",
   "assembly": {
     "namespace": "http",
     "components": [


### PR DESCRIPTION
NPM 5.6 fails on requiring this package when main directs to a directory without an index.